### PR TITLE
Fix macOS 26 compatibility by replacing JXA with AppleScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Bug Fixes
+
+- **Fix macOS 26 compatibility** — The JXA (JavaScript for Automation) API broke in macOS 26 (Darwin 25) in two ways: `Contacts.groups.whose()` is no longer a valid function, and the ObjC bridge used to write vCard data to stdout fails with error -1741. Both `getNumberOfContacts` and `getVCards` have been rewritten to use AppleScript instead of JXA. The `osascript` invocation no longer passes `-l JavaScript`. This fixes the symptom where the plugin correctly reported a contact count but imported zero files. (Relates to issues #18 and #19.)

--- a/__tests__/contactsService.test.ts
+++ b/__tests__/contactsService.test.ts
@@ -17,7 +17,6 @@ describe('Test ContactsService', () => {
     const groupName = 'testGroup';
     const enabledContactFields = 'nickname,emails,title,organization,telephones,addresses,birthdate,URLs,notes';
 
-
     beforeEach(() => {
         mockOsaScriptService = new MockOsaScriptService();
         contactsService = new ContactsService(groupName, enabledContactFields, mockOsaScriptService);
@@ -27,65 +26,65 @@ describe('Test ContactsService', () => {
         expect(contactsService).toBeDefined();
     });
 
-    test('getNumberOfContactsInGroup: valid response', async () => {
-        let testPromise = new Promise((resolve, reject) => {
-            resolve('3');
-        });
+    test('getNumberOfContacts: uses AppleScript (not JXA)', async () => {
+        mockOsaScriptService.executeScript.mockResolvedValue('0');
+        await contactsService.getNumberOfContacts();
+        const script: string = mockOsaScriptService.executeScript.mock.calls[0][0];
+        expect(script).toContain('tell application "Contacts"');
+        expect(script).not.toContain('-l JavaScript');
+        expect(script).not.toContain('whose');
+    });
 
-        mockOsaScriptService.executeScript.mockResolvedValue(testPromise);
+    test('getVCards: uses AppleScript (not JXA)', async () => {
+        mockOsaScriptService.executeScript.mockResolvedValue('');
+        await contactsService.getVCards();
+        const script: string = mockOsaScriptService.executeScript.mock.calls[0][0];
+        expect(script).toContain('tell application "Contacts"');
+        expect(script).not.toContain('ObjC.import');
+        expect(script).not.toContain('whose');
+    });
+
+    test('getNumberOfContacts: uses group name in script', async () => {
+        mockOsaScriptService.executeScript.mockResolvedValue('0');
+        await contactsService.getNumberOfContacts();
+        const script: string = mockOsaScriptService.executeScript.mock.calls[0][0];
+        expect(script).toContain(groupName);
+    });
+
+    test('getNumberOfContacts: valid response', async () => {
+        mockOsaScriptService.executeScript.mockResolvedValue('3');
         const result = await contactsService.getNumberOfContacts();
         expect(result).toBe(3);
     });
 
-    test('getNumberOfContactsInGroup: non-numeric reponse', async () => {
-    let testPromise = new Promise((resolve, reject) => {
-            resolve('abc');
-        });
-
-        mockOsaScriptService.executeScript.mockResolvedValue(testPromise);
+    test('getNumberOfContacts: non-numeric response', async () => {
+        mockOsaScriptService.executeScript.mockResolvedValue('abc');
         const resultPromise = contactsService.getNumberOfContacts();
-
-        expect(resultPromise).rejects.toThrow();
+        await expect(resultPromise).rejects.toThrow();
     });
 
-    test('getNumberOfContactsInGroup: error reponse', async () => {
-        let testPromise = new Promise((resolve, reject) => {
-            reject(new Error('dummy error'));
-        });
-
-        mockOsaScriptService.executeScript.mockResolvedValue(testPromise);
+    test('getNumberOfContacts: error response', async () => {
+        mockOsaScriptService.executeScript.mockRejectedValue(new Error('dummy error'));
         const resultPromise = contactsService.getNumberOfContacts();
-
-        expect(resultPromise).rejects.toThrow()
+        await expect(resultPromise).rejects.toThrow();
     });
 
     test.each(Array.from(TEST_VCARD_DATA))('getVCards: valid response: single vCard', async (vCardStr, vCard) => {
-        let testPromise = new Promise((resolve, reject) => {
-            resolve(vCardStr);
-        });
-        
-        mockOsaScriptService.executeScript.mockResolvedValue(testPromise);
-        const resultPromise = contactsService.getVCards();
-        expect(resultPromise).resolves.toEqual([vCard]);
+        mockOsaScriptService.executeScript.mockResolvedValue(vCardStr);
+        const result = await contactsService.getVCards();
+        expect(result).toEqual([vCard]);
     });
 
     test('getVCards: valid response: multiple vCards', async () => {
-        let testPromise = new Promise((resolve, reject) => {
-            resolve(Array.from(TEST_VCARD_DATA).join('\r\n'));
-        });
-        
-        mockOsaScriptService.executeScript.mockResolvedValue(testPromise);
-        const resultPromise = contactsService.getVCards();
-        expect(resultPromise).resolves.toEqual(Array.from(TEST_VCARD_DATA.values()));
+        const combined = Array.from(TEST_VCARD_DATA.keys()).join('\r\n');
+        mockOsaScriptService.executeScript.mockResolvedValue(combined);
+        const result = await contactsService.getVCards();
+        expect(result).toEqual(Array.from(TEST_VCARD_DATA.values()));
     });
 
     test('getVCards: error response', async () => {
-        let testPromise = new Promise((resolve, reject) => {
-            reject(new Error('dummy error'));
-        });
-        
-        mockOsaScriptService.executeScript.mockResolvedValue(testPromise);
+        mockOsaScriptService.executeScript.mockRejectedValue(new Error('dummy error'));
         const resultPromise = contactsService.getVCards();
-        expect(resultPromise).rejects.toThrow();
+        await expect(resultPromise).rejects.toThrow();
     });
 });

--- a/src/contactsService.ts
+++ b/src/contactsService.ts
@@ -20,12 +20,11 @@ export class ContactsService implements IContactsService {
 
     readonly GROUP_NOT_DEFINED_ERROR = "GROUP NOT DEFINED";
 
-    constructor(groupName: string, enabledContactFields: string, osaScriptService: IOsaScriptService = new OsaScriptService() ) {
+    constructor(groupName: string, enabledContactFields: string, osaScriptService: IOsaScriptService = new OsaScriptService()) {
 		this.groupName = groupName;
         this.enabledContactFields = enabledContactFields;
-		this.osaScriptService = osaScriptService
+		this.osaScriptService = osaScriptService;
     }
-
 
     async loadContacts(): Promise<Map<string, string>> {
         let vCards: VCard[] = await this.getVCards();
@@ -42,21 +41,21 @@ export class ContactsService implements IContactsService {
     }
 
     async getNumberOfContacts(): Promise<number> {
-        const JXA_SCRIPT = `
-			let Contacts = Application('Contacts');
-			Contacts.includeStandardAdditions = true;
+        const APPLESCRIPT = `
+tell application "Contacts"
+	try
+		set targetGroup to group "${this.groupName}"
+		count of people in targetGroup
+	on error
+		error "${this.GROUP_NOT_DEFINED_ERROR}"
+	end try
+end tell
+`;
 
-			let groups = Contacts.groups.whose({ name: '${this.groupName}'});
-			if (groups.length === 0 || groups === undefined || groups === null)
-			 	throw new Error('${this.GROUP_NOT_DEFINED_ERROR}');
-
-			groups[0].people.length;
-		`;
-
-		let resultPromise = this.osaScriptService.executeScript(JXA_SCRIPT).then<number>((resultStr) => {
+		let resultPromise = this.osaScriptService.executeScript(APPLESCRIPT).then<number>((resultStr) => {
 			let resultInt = parseInt(resultStr);
 			if (isNaN(resultInt)) {
-				throw new Error(`Non-numeric result from JXA script: ${resultStr}`);
+				throw new Error(`Non-numeric result from AppleScript: ${resultStr}`);
 			}
 			return resultInt;
 		})
@@ -65,30 +64,25 @@ export class ContactsService implements IContactsService {
 	}
 
     async getVCards(): Promise<VCard[]> {
-		const JXA_SCRIPT = `
-			ObjC.import('Foundation');
-			const stdout = $.NSFileHandle.fileHandleWithStandardOutput;
-
-			let Contacts = Application('Contacts');
-			Contacts.includeStandardAdditions = true;
-
-			let groups = Contacts.groups.whose({ name: '${this.groupName}'});
-			if (groups.length === 0 || groups === undefined || groups === null)
-			 	throw new Error('${this.GROUP_NOT_DEFINED_ERROR}');
-
-			for (let vcard of groups[0].people.vcard()) {
-				// Write to stdout
-				const nsString = $.NSString.alloc.initWithUTF8String(vcard);
-				const data = nsString.dataUsingEncoding($.NSUTF8StringEncoding);
-				stdout.writeData(data);
-			}
-		`;
+		const APPLESCRIPT = `
+tell application "Contacts"
+	try
+		set targetGroup to group "${this.groupName}"
+		set vcardData to ""
+		repeat with eachPerson in people of targetGroup
+			set vcardData to vcardData & vcard of eachPerson & return
+		end repeat
+		return vcardData
+	on error
+		error "${this.GROUP_NOT_DEFINED_ERROR}"
+	end try
+end tell
+`;
 		const vCardRegex = /BEGIN:VCARD[\s\S]*?END:VCARD/g;
 
+		let resultPromise = this.osaScriptService.executeScript(APPLESCRIPT).then<VCard[]>((vCardStr) => {
+			let matches = vCardStr.match(vCardRegex);
 
-		let resultPromise = this.osaScriptService.executeScript(JXA_SCRIPT).then<VCard[]>((vCardStr) => {
-			let matches =  vCardStr.match(vCardRegex);
-			
 			let vCards: VCard[] = [];
 			for (let match of matches ?? []) {
 				const card = new vcf().parse(match);

--- a/src/osascriptService.ts
+++ b/src/osascriptService.ts
@@ -1,29 +1,27 @@
 const { spawn } = require('child_process');
 
 export interface IOsaScriptService {
-    executeScript(JXA_script: string): Promise<string>;
+    executeScript(script: string): Promise<string>;
 }
 
 export class OsaScriptService implements IOsaScriptService {
-    async executeScript(JXA_script: string): Promise<string> {
+    async executeScript(script: string): Promise<string> {
         return new Promise<string>((resolve, reject) => {
-            // Start JXA Script
-            const osascript = spawn('osascript', ['-l', 'JavaScript', '-e', JXA_script]);
-            
+            const osascript = spawn('osascript', ['-e', script]);
+
             let output: string = '';
 			osascript.stdout.on('data', (data: Buffer) => {
 				output += data.toString('utf-8');
 			});
             osascript.stderr.on('data', (data: Buffer) => {
 				const errorMsg = data.toString('utf-8');
-				reject(new Error(`Error executing JXA script: \n${errorMsg}`));
+				reject(new Error(`Error executing AppleScript: \n${errorMsg}`));
 			});
             osascript.on('close', (code: number) => {
                 if (code === 0) {
-                    // If parsing fails, return the raw output
                     resolve(output);
                 } else {
-                    reject(new Error(`Error executing JXA script: \n${output}`));
+                    reject(new Error(`Error executing AppleScript: \n${output}`));
                 }
             });
         });


### PR DESCRIPTION
## Summary

- Replaces JXA (JavaScript for Automation) scripts in `getNumberOfContacts` and `getVCards` with AppleScript equivalents using stable `tell application "Contacts" / group "name"` syntax
- Removes the `-l JavaScript` flag from the `osascript` invocation
- Updates variable names and error messages to reflect the switch from JXA to AppleScript

## Problem

On macOS 26 (Darwin 25), two JXA APIs broke silently:
- `Contacts.groups.whose()` is no longer a valid function (issue #18)
- The ObjC bridge (`$.NSFileHandle.fileHandleWithStandardOutput`) used to stream vCard data to stdout fails with error -1741 (issue #19)

The symptom was: the plugin correctly reported a contact count ("Found N contacts") but imported zero files on every sync.

## Test plan

- [ ] Verify `getNumberOfContacts` and `getVCards` pass `tell application "Contacts"` AppleScript to `executeScript` (covered by new unit tests)
- [ ] Verify no JXA-specific APIs (`whose`, `ObjC.import`) appear in either script (covered by new unit tests)
- [ ] Run `npx jest` — all 11 tests pass
- [ ] Manual smoke test on macOS 26: trigger sync and confirm contacts are imported

Fixes #18, #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)